### PR TITLE
Demolition derby event

### DIFF
--- a/event_utils/spawn_helper.py
+++ b/event_utils/spawn_helper.py
@@ -86,17 +86,17 @@ class SpawnHelper:
 
         return ActiveBot(unique_name, team, randint(1, 2 ** 31 - 1), bundle)
 
-    def spawn_bot(self, bundle: BotConfigBundle) -> CompletedSpawn:
-        active_bot = self._make_active_bot(bundle, 0)
-        self.active_bots.append(active_bot)
+    def spawn_bots(self, bundles: List[BotConfigBundle]) -> List[CompletedSpawn]:
+        new_active_bots = [self._make_active_bot(bundle, 0) for bundle in bundles]
+        self.active_bots += new_active_bots
         match_config = build_match_config(self.active_bots)
         self.launch_match(match_config)
         packet = GameTickPacket()
         self.setup_manager.game_interface.update_live_data_packet(packet)
-        return CompletedSpawn(
+        return [CompletedSpawn(
             bot=active_bot,
             packet_index=index_from_spawn_id(packet, active_bot.spawn_id)
-        )
+        ) for active_bot in new_active_bots]
 
     def listen_for_events_supported_by_bot(self, timeout: int = 7) -> List[str]:
         """

--- a/event_utils/time_lord.py
+++ b/event_utils/time_lord.py
@@ -11,7 +11,14 @@ class TimeLord:
     Freezes a car in a particular place during the countdown to an event, then keeps track of elapsed time.
     """
 
-    def __init__(self, packet_index: int, position: Vector3, rotation: Rotator, game_interface: GameInterface):
+    def __init__(
+        self,
+        packet_index: int,
+        position: Vector3,
+        rotation: Rotator,
+        game_interface: GameInterface,
+        countdown_seconds=3,
+    ):
         self.packet_index = packet_index
         self.position = position
         self.rotation = rotation
@@ -22,7 +29,7 @@ class TimeLord:
         self.done_animating = False
         self.already_rendered = []
         self.render_group = "countdown"
-        self.countdown_seconds = 3
+        self.countdown_seconds = countdown_seconds
 
     def get_event_elapsed_time(self, packet: GameTickPacket):
         return packet.game_info.seconds_elapsed - self.event_start_time
@@ -35,7 +42,7 @@ class TimeLord:
         countdown_elapsed = packet.game_info.seconds_elapsed - self.countdown_start_time
         event_elapsed = countdown_elapsed - self.countdown_seconds
         if countdown_elapsed < self.countdown_seconds:
-            self.render_if_new(str(3 - int(countdown_elapsed)))
+            self.render_if_new(str(self.countdown_seconds - int(countdown_elapsed)))
             cars = {self.packet_index: CarState(
                 physics=Physics(
                     location=self.position.to_gamestate(),

--- a/events/demolition_derby.py
+++ b/events/demolition_derby.py
@@ -1,0 +1,212 @@
+"""
+Bot makers:
+
+To support this event type, you must listen on matchcomms for an event shaped like this (see DerbySpecification):
+{
+  "event_type": "DemolitionDerby",
+  "perma_death": true,
+  "max_duration": 60.0,
+  "starts": [
+    {
+      "location": {"x": 0.0, "y": -8000.0, "z": 50.0},
+      "rotation": {"pitch": 0.0, "yaw": 1.5707963267948966, "roll": 0.0},
+      "velocity": {"x": 0.0, "y": 0.0, "z": 0.0},
+      "angular_velocity": {"x": 0.0, "y": 0.0, "z": 0.0}
+    },
+    ...
+  ]
+}
+
+This event requires the Friendly Fire mutator.
+All bots spawn at once at the specified `starts`.
+The goal is to demo as many cars as you can, and avoid getting demoed.
+If `perma_death` is true, when your bot is demolished, it won't respawn (it actually does but it gets teleported outside the map).
+The event ends when there is only one bot alive or `max_duration` has passed.
+"""
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+import random
+from typing import List, Dict
+
+from mashumaro import DataClassJSONMixin
+from rlbot.utils.game_state_util import GameState, CarState, Physics as DesiredPhysics
+from rlbot.utils.structures.game_data_struct import GameTickPacket
+from rlbot.utils.structures.game_interface import GameInterface
+
+from competitor import Competitor
+from data_types.physics import Physics
+from data_types.rotator import Rotator
+from data_types.vector3 import Vector3
+from event import Event, EventMeta, EventStatus
+from event_utils.spawn_helper import ActiveBot, CompletedSpawn, SpawnHelper
+from event_utils.time_lord import TimeLord
+
+
+@dataclass
+class DerbySpecification(DataClassJSONMixin):
+    """
+    This will be saved in the file, and also sent to bots via matchcomms to tell them
+    they'll be competing and where each bot starts.
+    """
+    perma_death: bool
+    max_duration: float
+    starts: List[Physics]
+    event_type: str = "DemolitionDerby"
+
+
+@dataclass
+class EventDocument(DataClassJSONMixin):
+    derby_spec: DerbySpecification
+    competitor_cfg_files: List[str]
+    result_demolitions: Dict[str, int]
+
+
+@dataclass
+class ActiveBotInfo:
+    competitor: Competitor
+    active_bot: ActiveBot
+    packet_index: int
+    time_lord: TimeLord
+    is_dead: bool = False
+
+
+class DemolitionDerby(Event):
+    def __init__(self, max_duration=60, perma_death=True) -> None:
+        super().__init__()
+        self.max_duration = max_duration
+        self.perma_death = perma_death
+
+        self.name = "Demolition Derby"
+        self.file: Path = None
+        self.event_doc: EventDocument = None
+        
+        self.derby_started = False
+        self.infos: List[ActiveBotInfo] = None
+
+    def load_event(self, doc: EventMeta, spawn_helper: SpawnHelper, game_interface: GameInterface) -> None:
+        """
+        Loads the derby tracking document from disk and initializes game interface type stuff.
+        """
+        super().load_event(doc, spawn_helper, game_interface)
+        doc_text = Path(doc.event_doc_path).read_text()
+        self.event_doc = EventDocument.from_json(doc_text)
+        self.competitors = [Competitor.from_config_path(p) for p in self.event_doc.competitor_cfg_files]
+
+    def save_doc(self):
+        """
+        Writes the derby tracking document to disk.
+        """
+        json = self.event_doc.to_json()
+        path = Path(self.event_meta.event_doc_path)
+        path.write_text(json)
+
+    def init_event(self, competitors: List[Competitor], competition_dir: Path) -> EventMeta:
+        """
+        This should create a document that persists which bots are in the event,
+        and the progress and standings so far. If the program crashes, the
+        doc should be adequate for picking up where we left off.
+
+        Anything using random number generation should be done here.
+        """
+        super().init_event(competitors, competition_dir)
+
+        # arrange all bots in a circle
+        spawn_angles = [2 * math.pi * i / len(competitors) for i in range(len(competitors))]
+        radius = 3000
+        spawn_physics = [Physics(
+            location=Vector3(math.cos(angle) * radius, math.sin(angle) * radius, 50),
+            rotation=Rotator(0, angle + math.pi, 0),
+            velocity=Vector3(0, 0, 0),
+            angular_velocity=Vector3(0, 0, 0)
+        ) for angle in spawn_angles]
+        random.shuffle(spawn_physics)  # randomize spawn positions
+
+        derby_spec = DerbySpecification(perma_death=self.perma_death, max_duration=self.max_duration, starts=spawn_physics)
+        event_doc = EventDocument(
+            derby_spec=derby_spec,
+            competitor_cfg_files=[c.bundle.config_path for c in competitors],
+            result_demolitions={}
+        )
+
+        self.file = self.competition_dir / 'DemolitionDerby.json'
+        self.file.write_text(event_doc.to_json())
+
+        return EventMeta(event_type='DemolitionDerby', event_doc_path=str(self.file))
+
+    def start_derby(self):
+        derby_spec = self.event_doc.derby_spec
+        self.spawn_helper.clear_bots()
+
+        self.on_screen_log.log(f"About to spawn bots for DemolitionDerby.")
+        completed_spawns = self.spawn_helper.spawn_bots([competitor.bundle for competitor in self.competitors])
+
+        self.on_screen_log.log("Waiting for bots to get ready")
+        # We expect a number of ready messages equal to the number of competitors. Doesn't matter in which order they arrive.
+        # Currently we have no way of knowing which bot sent which message, so we don't know who supports this event.
+        for i in range(len(self.competitors)):
+            self.hide_ball()
+            self.spawn_helper.listen_for_events_supported_by_bot(timeout=7)
+            self.on_screen_log.log(f"{i+1}/{len(self.competitors)} bots ready")
+
+        self.broadcast_to_bots(derby_spec.to_dict())
+
+        self.game_interface.set_game_state(GameState(cars={spawn.packet_index: CarState(
+            physics=start.to_gamestate(),
+            boost_amount=0
+        ) for spawn, start in zip(completed_spawns, derby_spec.starts)}))
+
+        self.hide_ball()
+
+        self.infos = [ActiveBotInfo(
+            competitor=competitor,
+            active_bot=spawn.bot,
+            packet_index=spawn.packet_index,
+            time_lord=TimeLord(
+                spawn.packet_index,
+                start.location,
+                start.rotation,
+                self.game_interface,
+                countdown_seconds=10,
+            ),
+        ) for spawn, competitor, start in zip(completed_spawns, self.competitors, derby_spec.starts)]
+
+        self.on_screen_log.log("Starting derby!")
+        self.derby_started = True
+
+    def tick_event(self, packet: GameTickPacket) -> EventStatus:
+        """
+        This is the main logic for running the derby.
+        It spawns all the cars and tracks their demolitions.
+        """
+        if not self.derby_started:
+            self.start_derby()
+            return EventStatus(is_complete=False)  # exit out of this tick so we can get a fresh packet
+
+        car_states = {}
+        for info in self.infos:
+            info.time_lord.tick(packet)
+            if not info.is_dead and self.perma_death and packet.game_cars[info.packet_index].is_demolished:
+                info.is_dead = True
+                self.on_screen_log.log(f"{info.competitor.name()} is permanently dead")
+
+            # hide dead bots
+            if info.is_dead:
+                car_states[info.packet_index] = CarState(DesiredPhysics(
+                    location=Vector3(info.packet_index * 100, 0, 3000).to_gamestate()))
+
+        # if only one bot is alive or we ran out of time, end the event
+        bots_alive = sum(not info.is_dead for info in self.infos)
+        if bots_alive <= 1 or self.infos[0].time_lord.get_event_elapsed_time(packet) > self.max_duration:
+            for info in self.infos:
+                demos_scored = packet.game_cars[info.packet_index].score_info.demolitions
+                self.event_doc.result_demolitions[info.competitor.bundle.config_path] = demos_scored
+                info.time_lord.cleanup()
+            self.on_screen_log.clear()
+            self.save_doc()
+            return EventStatus(is_complete=True)
+
+        self.game_interface.set_game_state(GameState(cars=car_states))
+        return EventStatus(is_complete=False)
+

--- a/events/waypoint_race.py
+++ b/events/waypoint_race.py
@@ -198,7 +198,7 @@ class WaypointRace(Event):
         bot_name = self.active_competitor.name()
 
         self.on_screen_log.log(f"About to spawn {bot_name} for WaypointRace.")
-        completed_spawn = self.spawn_helper.spawn_bot(self.active_competitor.bundle)
+        completed_spawn = self.spawn_helper.spawn_bots([self.active_competitor.bundle])[0]
         supported_events = self.spawn_helper.listen_for_events_supported_by_bot(timeout=7)
         self.is_event_supported(bot_name, supported_events)
         self.broadcast_to_bots(race_spec.to_dict())

--- a/track_and_field.py
+++ b/track_and_field.py
@@ -12,6 +12,7 @@ from rlbot_gui.gui import get_team_settings
 from competitor import Competitor
 from event import Event, EventMeta
 from event_utils.spawn_helper import SpawnHelper
+from events.demolition_derby import DemolitionDerby
 from events.waypoint_race import WaypointRace
 from ui.on_screen_log import OnScreenLog
 from ui.wait_for_press import KeyWaiter
@@ -74,6 +75,8 @@ class TrackAndField(BaseScript):
     def construct_event(self, event_type: str) -> Event:
         if event_type == 'WaypointRace':
             return WaypointRace()
+        if event_type == 'DemolitionDerby':
+            return DemolitionDerby()
 
     def construct_and_load(self, event_doc: EventMeta) -> Event:
         event = self.construct_event(event_doc.event_type)
@@ -106,7 +109,7 @@ def get_event_list():
     """
     These are the track and field events which will be initialized for new competitions.
     """
-    return [WaypointRace()]
+    return [WaypointRace(), DemolitionDerby()]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This event requires the Friendly Fire mutator.
All bots spawn at once at the specified `starts` - on random positions on a circle around the center.
The goal is to demo as many cars as you can, and avoid getting demoed.
If `perma_death` is true, when your bot is demolished, it won't respawn (it actually does but it gets teleported outside the map).
The event ends when there is only one bot alive or `max_duration` has passed.